### PR TITLE
fix: `compile_for` doesn't work at all

### DIFF
--- a/.changes/compile_for.md
+++ b/.changes/compile_for.md
@@ -1,0 +1,5 @@
+---
+'winres': patch
+---
+
+`compile_for` didn't work at all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,13 +559,13 @@ impl WindowsResource {
         let rc = output.join("resource.rc");
 
         if let Some(s) = self.rc_file.as_ref() {
-            fs::write(&output, s)?;
+            fs::write(&rc, s)?;
         } else {
-            self.write_resource_file(rc)?;
+            self.write_resource_file(&rc)?;
         }
 
         // This matches v2 behavior
-        embed_resource::compile_for("resource.rc", binaries, embed_resource::NONE)
+        embed_resource::compile_for(rc, binaries, embed_resource::NONE)
             .manifest_required()
             .unwrap();
 


### PR DESCRIPTION
All the paths were wrong, mirrored the code from `compile`

Closes #38